### PR TITLE
Use pythonic naming for Slack webhook option name

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ We can publish messages to Slack with code:
 ```python
 sink_config = dict(kind='slack-sink',
                    channel=slack_channel,
-                   webhookUrl=slack_webhook)
+                   webhook_url=slack_webhook)
 sink = rayvens.Stream('slack', sink_config=sink_config)
 ```
 
@@ -429,7 +429,7 @@ In addition to the same source as before, it instantiates a sink:
 sink = rayvens.Stream('slack')
 sink_config = dict(kind='slack-sink',
                    channel=slack_channel,
-                   webhookUrl=slack_webhook)
+                   webhook_url=slack_webhook)
 sink.add_sink(sink_config)
 ```
 
@@ -535,7 +535,7 @@ source_config = dict(
 
 sink_config = dict(kind='slack-sink',
                    channel=slack_channel,
-                   webhookUrl=slack_webhook)
+                   webhook_url=slack_webhook)
 
 operator = rayvens.Stream('comparator',
                           source_config=source_config,

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -32,7 +32,7 @@ The general usage is to first create the configuration:
 ```
 sink_configuration = dict(kind='slack-sink',
                           channel='channel_name',
-                          webhookUrl='valid_webhook_url')
+                          webhook_url='valid_webhook_url')
 ```
 
 followed by the creation of the sink based on the configuration:
@@ -231,7 +231,7 @@ json_event['event_type']
 
 Outputs a message to a Slack channel provided by the user. It supports the following fields:
 - `channel` the output channel name
-- `webhookUrl` the webhook URL belonging to the channel to which the message is being sent
+- `webhook_url` the webhook URL belonging to the channel to which the message is being sent
 
 ### `kind="kafka-sink"`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -188,7 +188,7 @@ In `slack.py` a Slack sink is configured:
 ```
 sink_config = dict(kind='slack-sink',
                    channel=slack_channel,
-                   webhookUrl=slack_webhook)
+                   webhook_url=slack_webhook)
 sink = rayvens.Stream('slack', sink_config=sink_config)
 ```
 

--- a/examples/aapl.py
+++ b/examples/aapl.py
@@ -56,7 +56,7 @@ if slack_channel != '':
     # create a sink stream
     sink_config = dict(kind='slack-sink',
                        channel=slack_channel,
-                       webhookUrl=slack_webhook)
+                       webhook_url=slack_webhook)
     sink = rayvens.Stream('slack', sink_config=sink_config)
 
     # actor to compare APPL quote with last quote

--- a/examples/kafka/kafka_event_streaming_sink.py
+++ b/examples/kafka/kafka_event_streaming_sink.py
@@ -61,7 +61,7 @@ stream = rayvens.Stream('slack')
 # Event sink config.
 sink_config = dict(kind='slack-sink',
                    channel=slack_channel,
-                   webhookUrl=slack_webhook,
+                   webhook_url=slack_webhook,
                    kafka_transport_topic=topic,
                    kafka_transport_partitions=3)
 

--- a/examples/slack/slack.py
+++ b/examples/slack/slack.py
@@ -55,7 +55,7 @@ source >> (lambda event: print('LOG:', event))
 # create a sink stream
 sink_config = dict(kind='slack-sink',
                    channel=slack_channel,
-                   webhookUrl=slack_webhook)
+                   webhook_url=slack_webhook)
 sink = rayvens.Stream('slack', sink_config=sink_config)
 
 

--- a/examples/slack/slack_operator_mode.py
+++ b/examples/slack/slack_operator_mode.py
@@ -46,7 +46,7 @@ stream = rayvens.Stream('slack')
 sink_config = dict(kind='slack-sink',
                    route='/toslack',
                    channel=slack_channel,
-                   webhookUrl=slack_webhook)
+                   webhook_url=slack_webhook)
 
 # Add sink to stream.
 sink = stream.add_sink(sink_config)

--- a/rayvens/core/catalog.py
+++ b/rayvens/core/catalog.py
@@ -363,14 +363,14 @@ def construct_source(config, endpoint, inverted=False):
 def slack_sink(config):
     if 'channel' not in config:
         raise TypeError('Kind slack-sink requires a channel.')
-    if 'webhookUrl' not in config:
-        raise TypeError('Kind slack-sink requires a webhookUrl.')
+    if 'webhook_url' not in config:
+        raise TypeError('Kind slack-sink requires a webhook url.')
     channel = config['channel']
-    webhookUrl = config['webhookUrl']
+    webhook_url = config['webhook_url']
 
     final_spec = {
         'steps': [{
-            'to': f'slack:{channel}?webhookUrl={webhookUrl}',
+            'to': f'slack:{channel}?webhookUrl={webhook_url}',
         }]
     }
 


### PR DESCRIPTION
Use pythonic naming for Slack webhook option name.