### PR TITLE
Fix logging of kamel commands

### DIFF
--- a/rayvens/core/invocation.py
+++ b/rayvens/core/invocation.py
@@ -152,31 +152,47 @@ class KamelInvocation:
                             end_condition,
                             with_output=False,
                             with_timeout=False):
-        # Implicit 30s timer.
+        # Implicit 5 minute timer.
         countdown = None
         if with_timeout:
-            countdown = 30
+            countdown = 5 * 60 * 100  # hundredths of a second
+        reading_thread = utils.LogThread(self.process.stdout)
+
+        # Kill thread when program ends in case it does not end before that.
+        reading_thread.daemon = True
+
+        # Start thread analyzing logs:
+        reading_thread.start()
+
+        success = False
         while True:
             # Log progress of kamel subprocess:
-            output = utils.print_log_from_subprocess(self.subprocess_name,
-                                                     self.process.stdout,
-                                                     with_output=with_output)
+            output = utils.print_log_from_queue(self.subprocess_name,
+                                                reading_thread.queue,
+                                                with_output, not with_timeout)
 
             # Use the Kamel output to decide when Kamel instance is
             # ready to receive requests.
-            if end_condition in output:
-                return True
+            if output is not None and end_condition in output:
+                success = True
+                break
 
             # Check process has not exited prematurely.
             if self.process.poll() is not None:
                 break
+
+            # If timeout is enabled we decrement countdown.
             if with_timeout:
                 countdown -= 1
                 if countdown == 0:
-                    return False
-                time.sleep(1)
+                    break
+                time.sleep(0.01)
 
-        return False
+        # Terminate log thread:
+        reading_thread.stop_flag.set()
+        reading_thread.join()
+
+        return success
 
 
 #


### PR DESCRIPTION
Fix logging of kamel commands by making the reading of the kamel command output non-blocking.